### PR TITLE
Added module files to add ability to import-module

### DIFF
--- a/rfa-backups.psd1
+++ b/rfa-backups.psd1
@@ -1,0 +1,92 @@
+# All below copied from PSExcel module, with the DLL part removed. 
+# If youwant to copy, just change the PSM1 file name to match yours, 
+#  and run "New-Guid|clip" in PoSh to generate a new guid for your module. 
+# Also RequiredModules
+
+@{
+
+# Script module or binary module file associated with this manifest.
+ModuleToProcess = 'rfa-backups.psm1'
+
+# Version number of this module.
+#ModuleVersion = '0.0.1.0'
+
+# ID used to uniquely identify this module
+GUID = 'c3c79a34-408a-473e-a3e2-7e391782cdeb'
+
+# Author of this module
+#Author = ''
+
+# Company or vendor of this module
+# CompanyName = 'RFA, Inc.'
+
+# Copyright statement for this module
+# Copyright = ''
+
+# Description of the functionality provided by this module
+#Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+#PowerShellVersion = '5.1'
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of Microsoft .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+# FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+# CmdletsToExport = '*'
+
+# Variables to export from this module
+# VariablesToExport = '*'
+
+# Aliases to export from this module
+# AliasesToExport = '*'
+
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}

--- a/rfa-backups.psm1
+++ b/rfa-backups.psm1
@@ -1,0 +1,33 @@
+# All below copied from PSExcel module, with the DLL part removed. 
+
+#handle PS2
+    if(-not $PSScriptRoot)
+    {
+        $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+    }
+
+#Get public and private function definition files.
+    $Public  = Get-ChildItem $PSScriptRoot\*-functions.ps1 -ErrorAction SilentlyContinue
+#    $Private  = Get-ChildItem $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue
+
+#Dot source the files
+    Foreach($import in @($Public))
+    {
+        Try
+        {
+            #PS2 compatibility
+            if($import.fullname)
+            {
+                . $import.fullname
+            }
+        }
+        Catch
+        {
+            Write-Error "Failed to import function $($import.fullname): $_"
+        }
+    }
+    
+#Create some aliases, export public functions
+Export-ModuleMember -Function $($Public | Select -ExpandProperty BaseName) -Alias *
+
+


### PR DESCRIPTION
Used the existing file naming convention to determine which files had functions vs scripts.

PSM1 file customized to only load *-functions.ps1 files. PSD1 file has minimum info to allow import.

Now you can run 
`ipmo rfa-backups`
And use the functions from a command line. 
